### PR TITLE
feat: add configurable webhook host

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -41,6 +41,7 @@ func main() {
 		LeaderElectionNamespace: config.Config.LeaderElectionNamespace,
 		LeaderElectionID:        config.Config.LeaderElectionName,
 		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    config.Config.WebhookHost,
 			Port:    config.Config.WebhookPort,
 			CertDir: constants.WebhookCertPath,
 			TLSOpts: []func(*tls.Config){

--- a/deploy/chart/templates/webhook/webhook.yaml
+++ b/deploy/chart/templates/webhook/webhook.yaml
@@ -9,7 +9,7 @@ webhooks:
     clientConfig:
       # CaBundle must set as the ca for secret everoute-controller-tls.
       caBundle: {{ .Values.webhook.caBundle }}
-      url: https://127.0.0.1:{{ .Values.webhook.port }}/validate-tr-everoute-io-v1alpha1-rule
+      url: https://{{ .Values.webhook.host }}:{{ .Values.webhook.port }}/validate-tr-everoute-io-v1alpha1-rule
     failurePolicy: Fail
     name: rule.tr.io
     rules:
@@ -35,7 +35,7 @@ webhooks:
     clientConfig:
       # CaBundle must set as the ca for secret everoute-controller-tls.
       caBundle: {{ .Values.webhook.caBundle }}
-      url: https://127.0.0.1:{{ .Values.webhook.port }}/mutate-tr-everoute-io-v1alpha1-rule
+      url: https://{{ .Values.webhook.host }}:{{ .Values.webhook.port }}/mutate-tr-everoute-io-v1alpha1-rule
     failurePolicy: Fail
     name: rule.tr.io
     rules:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,3 +1,4 @@
 webhook:
   caBundle: Cg==
+  host: 127.0.0.1
   port: 9603

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ var Config T
 type T struct {
 	MetricsAddr string
 	HealthAddr  string
+	WebhookHost string
 	WebhookPort int
 
 	EnableLeaderElection    bool
@@ -40,6 +41,7 @@ func InitFlags(flagset *flag.FlagSet) {
 
 	flagset.StringVar(&Config.MetricsAddr, "metrics-addr", ":9605", "the metrics address")
 	flagset.StringVar(&Config.HealthAddr, "health-addr", ":9601", "the health address")
+	flagset.StringVar(&Config.WebhookHost, "webhook-host", "127.0.0.1", "the webhook host")
 	flagset.IntVar(&Config.WebhookPort, "webhook-port", 9603, "the webhook port")
 	flagset.BoolVar(&Config.EnableLeaderElection, "enable-leader-election", true, "enable leader election or not")
 	flagset.StringVar(&Config.LeaderElectionNamespace, "leader-election-namespace", "kube-system", "the namespace of leader election lease")


### PR DESCRIPTION
## Purpose

Allow trafficredirect controller webhook bind host to be configured separately from its port.

## Changes

- Add `--webhook-host` with default `127.0.0.1` while keeping `--webhook-port`.
- Pass the configured host into controller-runtime webhook server options.
- Add `webhook.host` to the Helm chart and build admission webhook URLs from host and port.

## Tests

- `go test ./cmd/controller ./pkg/config`
- `helm template tr deploy/chart`
-  部署后，只监听127.0.0.1
<img width="1437" height="148" alt="image" src="https://github.com/user-attachments/assets/8da85552-5a25-45b8-9125-ce574f27facc" />

