### PR TITLE
feat(ER-1652): configure tower crc watch scheme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0
-	github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786
+	github.com/everoute/graphc v0.0.0-20260617090527-726c46259e21
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/evanphx/json-patch/v5 v5.7.0 h1:nJqP7uwL84RJInrohHfW0Fx3awjbm8qZeFv0n
 github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786 h1:6V/pwZD//tGz/dMXZr8QjhUkOd1yOORyFjtDdcqT9Xk=
 github.com/everoute/graphc v0.0.0-20260311060513-4046a92a8786/go.mod h1:7qfJw7/eKRaSpiwi2ClmCIo1KWpwp6oec67Ln8hg8Kg=
+github.com/everoute/graphc v0.0.0-20260617084607-e469e6aea7ed h1:BoPqFk0HGI/ubbcdDvUI/2y4HuahGQPXDYT/O/qZldc=
+github.com/everoute/graphc v0.0.0-20260617084607-e469e6aea7ed/go.mod h1:7qfJw7/eKRaSpiwi2ClmCIo1KWpwp6oec67Ln8hg8Kg=
+github.com/everoute/graphc v0.0.0-20260617090527-726c46259e21 h1:RGmW6REg9Fz9Svewnsm186yFTDR2zl5M+xi1Y4wqZ/Y=
+github.com/everoute/graphc v0.0.0-20260617090527-726c46259e21/go.mod h1:7qfJw7/eKRaSpiwi2ClmCIo1KWpwp6oec67Ln8hg8Kg=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type T struct {
 type TowerOpts struct {
 	AllowInsecure      bool
 	Addr               string
+	Scheme             string
 	Username           string
 	Password           string
 	Source             string
@@ -47,6 +48,7 @@ func InitFlags(flagset *flag.FlagSet) {
 
 	flagset.BoolVar(&Config.Tower.AllowInsecure, "tower-allow-insecure", true, "tower allow-insecure for authenticate")
 	flagset.StringVar(&Config.Tower.Addr, "tower-addr", "", "tower api address host:port")
+	flagset.StringVar(&Config.Tower.Scheme, "tower-scheme", "http", "tower resource change event watch scheme")
 	flagset.StringVar(&Config.Tower.Username, "tower-username", os.Getenv("TOWER_USERNAME"), "tower username for authenticate")
 	flagset.StringVar(&Config.Tower.Password, "tower-password", os.Getenv("TOWER_PASSWORD"), "tower user password for authenticate")
 	flagset.StringVar(&Config.Tower.Source, "tower-source", os.Getenv("TOWER_USERSOURCE"), "tower user source for authenticate")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestInitFlagsTowerScheme(t *testing.T) {
+	oldConfig := Config
+	defer func() { Config = oldConfig }()
+
+	Config = T{}
+	flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+	InitFlags(flagset)
+
+	if err := flagset.Parse(nil); err != nil {
+		t.Fatalf("parse default flags: %v", err)
+	}
+	if Config.Tower.Scheme != "http" {
+		t.Fatalf("expected default tower scheme http, got %q", Config.Tower.Scheme)
+	}
+
+	Config = T{}
+	flagset = flag.NewFlagSet("test", flag.ContinueOnError)
+	InitFlags(flagset)
+	if err := flagset.Parse([]string{"--tower-scheme=https"}); err != nil {
+		t.Fatalf("parse explicit flags: %v", err)
+	}
+	if Config.Tower.Scheme != "https" {
+		t.Fatalf("expected explicit tower scheme https, got %q", Config.Tower.Scheme)
+	}
+}

--- a/pkg/tower/client/watch.go
+++ b/pkg/tower/client/watch.go
@@ -21,6 +21,7 @@ func NewCRCWatch(resourceTypes []datamodel.ResourceType) (*crcwatch.Watch, error
 	return crcwatch.NewWatch(resTypes, crcwatch.SetUserInfo(userInfo),
 		crcwatch.SetAPIAuth(config.Config.Tower.APIUsername, config.Config.Tower.APIPassword),
 		crcwatch.SetHost(config.Config.Tower.Addr),
+		crcwatch.SetScheme(config.Config.Tower.Scheme),
 		crcwatch.SetPollingInterval(config.Config.Tower.CrcInterval),
 		crcwatch.SetCatchUpPollingInterval(config.Config.Tower.CrcCatchUpInterval),
 		crcwatch.SetLimit(int32(config.Config.Tower.CrcLimit)))


### PR DESCRIPTION
## Summary
- add tower-scheme flag for CRC watch client
- pass the scheme to graphc crcwatch
- bump graphc to include crcwatch SetScheme support

## Dependency
- Requires https://github.com/everoute/graphc/pull/12

## Tests
- go test ./pkg/config ./pkg/tower/client -count=1