### PR TITLE
feat(ER-1652): split tower http and https addresses

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,8 @@ type T struct {
 type TowerOpts struct {
 	AllowInsecure      bool
 	Addr               string
+	HTTPSAddr          string
+	HTTPAddr           string
 	Username           string
 	Password           string
 	Source             string
@@ -32,6 +34,20 @@ type TowerOpts struct {
 	CrcInterval        time.Duration
 	CrcCatchUpInterval time.Duration
 	CrcLimit           int
+}
+
+func (o TowerOpts) HTTPSAddress() string {
+	if o.HTTPSAddr != "" {
+		return o.HTTPSAddr
+	}
+	return o.Addr
+}
+
+func (o TowerOpts) HTTPAddress() string {
+	if o.HTTPAddr != "" {
+		return o.HTTPAddr
+	}
+	return o.HTTPSAddress()
 }
 
 func InitFlags(flagset *flag.FlagSet) {
@@ -48,7 +64,9 @@ func InitFlags(flagset *flag.FlagSet) {
 	flagset.StringVar(&Config.LeaderElectionName, "leader-election-name", "tr-controller.leader-election.everoute.io", "the name of leader election lease")
 
 	flagset.BoolVar(&Config.Tower.AllowInsecure, "tower-allow-insecure", true, "tower allow-insecure for authenticate")
-	flagset.StringVar(&Config.Tower.Addr, "tower-addr", "", "tower api address host:port")
+	flagset.StringVar(&Config.Tower.Addr, "tower-addr", "", "tower https api address host:port (deprecated, use --tower-https-addr)")
+	flagset.StringVar(&Config.Tower.HTTPSAddr, "tower-https-addr", "", "tower https api address host:port")
+	flagset.StringVar(&Config.Tower.HTTPAddr, "tower-http-addr", "", "tower http api address host:port")
 	flagset.StringVar(&Config.Tower.Username, "tower-username", os.Getenv("TOWER_USERNAME"), "tower username for authenticate")
 	flagset.StringVar(&Config.Tower.Password, "tower-password", os.Getenv("TOWER_PASSWORD"), "tower user password for authenticate")
 	flagset.StringVar(&Config.Tower.Source, "tower-source", os.Getenv("TOWER_USERSOURCE"), "tower user source for authenticate")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,69 @@
+package config_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/everoute/trafficredirect/pkg/config"
+)
+
+func TestTowerOptsAddrValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      config.TowerOpts
+		wantHTTPS string
+		wantHTTP  string
+	}{
+		{
+			name:      "uses explicit https and http addresses",
+			opts:      config.TowerOpts{HTTPSAddr: "127.0.0.1:21003", HTTPAddr: "127.0.0.1:21002"},
+			wantHTTPS: "127.0.0.1:21003",
+			wantHTTP:  "127.0.0.1:21002",
+		},
+		{
+			name:      "falls back http address to https address",
+			opts:      config.TowerOpts{HTTPSAddr: "127.0.0.1:21003"},
+			wantHTTPS: "127.0.0.1:21003",
+			wantHTTP:  "127.0.0.1:21003",
+		},
+		{
+			name:      "keeps legacy tower address as https fallback",
+			opts:      config.TowerOpts{Addr: "tower.example:443"},
+			wantHTTPS: "tower.example:443",
+			wantHTTP:  "tower.example:443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.HTTPSAddress(); got != tt.wantHTTPS {
+				t.Fatalf("HTTPSAddress() = %q, want %q", got, tt.wantHTTPS)
+			}
+			if got := tt.opts.HTTPAddress(); got != tt.wantHTTP {
+				t.Fatalf("HTTPAddress() = %q, want %q", got, tt.wantHTTP)
+			}
+		})
+	}
+}
+
+func TestInitFlagsTowerAddrs(t *testing.T) {
+	config.Config = config.T{}
+	flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+	config.InitFlags(flagset)
+
+	err := flagset.Parse([]string{
+		"--tower-addr=tower.example:443",
+		"--tower-https-addr=127.0.0.1:21003",
+		"--tower-http-addr=127.0.0.1:21002",
+	})
+	if err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	if got := config.Config.Tower.HTTPSAddress(); got != "127.0.0.1:21003" {
+		t.Fatalf("HTTPSAddress() = %q, want %q", got, "127.0.0.1:21003")
+	}
+	if got := config.Config.Tower.HTTPAddress(); got != "127.0.0.1:21002" {
+		t.Fatalf("HTTPAddress() = %q, want %q", got, "127.0.0.1:21002")
+	}
+}

--- a/pkg/tower/client/client.go
+++ b/pkg/tower/client/client.go
@@ -20,7 +20,7 @@ type Client struct {
 
 func NewClient() *Client {
 	cli := &graphcclient.Client{
-		URL: "https://" + config.Config.Tower.Addr + "/api",
+		URL: "https://" + config.Config.Tower.HTTPSAddress() + "/api",
 		UserInfo: &graphcclient.UserInfo{
 			Username: config.Config.Tower.Username,
 			Password: config.Config.Tower.Password,

--- a/pkg/tower/client/watch.go
+++ b/pkg/tower/client/watch.go
@@ -20,7 +20,7 @@ func NewCRCWatch(resourceTypes []datamodel.ResourceType) (*crcwatch.Watch, error
 	}
 	return crcwatch.NewWatch(resTypes, crcwatch.SetUserInfo(userInfo),
 		crcwatch.SetAPIAuth(config.Config.Tower.APIUsername, config.Config.Tower.APIPassword),
-		crcwatch.SetHost(config.Config.Tower.Addr),
+		crcwatch.SetHost(config.Config.Tower.HTTPAddress()),
 		crcwatch.SetPollingInterval(config.Config.Tower.CrcInterval),
 		crcwatch.SetCatchUpPollingInterval(config.Config.Tower.CrcCatchUpInterval),
 		crcwatch.SetLimit(int32(config.Config.Tower.CrcLimit)))


### PR DESCRIPTION
## Summary
- add separate tower HTTPS and HTTP address flags
- keep --tower-addr as a deprecated HTTPS fallback
- use HTTPS address for the GraphQL client and HTTP address for crcwatch

## Tests
- GOCACHE=/tmp/tr-gocache go test -gcflags=all=-l ./... -count=1